### PR TITLE
Add integration test with asciidoc importer plugin

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,13 +43,6 @@ jobs:
         key: ${{ runner.os }}-java-${{ matrix.java }}-sonar
         restore-keys: ${{ runner.os }}-java-${{ matrix.java }}-sonar
 
-    - name: Build AsciiDoc importer plugin
-      run: |
-        cd ..
-        git clone https://github.com/SoftwareDefinedVehicle/openfasttrace-asciidoc-plugin.git --depth 1 --single-branch --branch initial_contribution
-        cd openfasttrace-asciidoc-plugin
-        mvn --batch-mode clean package -DskipTests
-
     - name: Build with Maven
       run: mvn --errors --batch-mode clean org.jacoco:jacoco-maven-plugin:prepare-agent install -Djava.version=${{ matrix.java }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,13 @@ jobs:
         key: ${{ runner.os }}-java-${{ matrix.java }}-sonar
         restore-keys: ${{ runner.os }}-java-${{ matrix.java }}-sonar
 
+    - name: Build AsciiDoc importer plugin
+      run: |
+        cd ..
+        git clone https://github.com/SoftwareDefinedVehicle/openfasttrace-asciidoc-plugin.git --depth 1 --single-branch --branch initial_contribution
+        cd openfasttrace-asciidoc-plugin
+        mvn clean package -DskipTests
+
     - name: Build with Maven
       run: mvn --errors --batch-mode clean org.jacoco:jacoco-maven-plugin:prepare-agent install -Djava.version=${{ matrix.java }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
         cd ..
         git clone https://github.com/SoftwareDefinedVehicle/openfasttrace-asciidoc-plugin.git --depth 1 --single-branch --branch initial_contribution
         cd openfasttrace-asciidoc-plugin
-        mvn clean package -DskipTests
+        mvn --batch-mode clean package -DskipTests
 
     - name: Build with Maven
       run: mvn --errors --batch-mode clean org.jacoco:jacoco-maven-plugin:prepare-agent install -Djava.version=${{ matrix.java }}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,6 +11,11 @@
     "java.sources.organizeImports.staticStarThreshold": 3,
     "java.configuration.updateBuildConfiguration": "automatic",
     "java.compile.nullAnalysis.mode": "automatic",
+    "java.test.config": {
+        "vmArgs": [
+            "-Djava.util.logging.config.file=src/test/resources/logging.properties"
+        ]
+    },
     "sonarlint.connectedMode.project": {
         "connectionId": "itsallcode",
         "projectKey": "org.itsallcode:openfasttrace-maven-plugin"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- [PR #65](https://github.com/itsallcode/openfasttrace-maven-plugin/pull/65) Add integration test using an OFT plugin
+
 ## [2.0.0] - 2024-06-09
 
 - [PR #64](https://github.com/itsallcode/openfasttrace-maven-plugin/pull/64) Upgrade to [OpenFastTrace 4.0.0](https://github.com/itsallcode/openfasttrace/releases/tag/4.0.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- [PR #65](https://github.com/itsallcode/openfasttrace-maven-plugin/pull/65) Add integration test using an OFT plugin
+## [2.1.0] -2024-08-11
+
+- [PR #65](https://github.com/itsallcode/openfasttrace-maven-plugin/pull/65) Add integration test using an OFT plugin and upgrade to [OpenFastTrace 4.1.0](https://github.com/itsallcode/openfasttrace/releases/tag/4.1.0)
 
 ## [2.0.0] - 2024-06-09
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Add the openfasttrace-maven-plugin to your `pom.xml`:
 <plugin>
     <groupId>org.itsallcode</groupId>
     <artifactId>openfasttrace-maven-plugin</artifactId>
-    <version>2.0.0</version>
+    <version>2.1.0</version>
     <executions>
         <execution>
             <id>trace-requirements</id>
@@ -67,7 +67,7 @@ You can use OpenFastTrace plugins to import and export requirements in additiona
 <plugin>
     <groupId>org.itsallcode</groupId>
     <artifactId>openfasttrace-maven-plugin</artifactId>
-    <version>2.0.0</version>
+    <version>2.1.0</version>
     <configuration>
         <failBuild>true</failBuild>
     </configuration>
@@ -75,7 +75,7 @@ You can use OpenFastTrace plugins to import and export requirements in additiona
         <dependency>
             <groupId>org.itsallcode</groupId>
             <artifactId>openfasttrace-asciidoc-plugin</artifactId>
-            <version>0.1.0</version>
+            <version>0.2.0</version>
         </dependency>
     </dependencies>
 </plugin>

--- a/README.md
+++ b/README.md
@@ -59,6 +59,28 @@ The plugin binds to the `verify` lifecycle, so you can also use `mvn verify`.
 
 See [src/test/resources/empty-project](src/test/resources/simple-project) for an example project.
 
+### OpenFastTrace Plugins
+
+You can use OpenFastTrace plugins to import and export requirements in additional formats. Include plugins by adding them as a dependency to the `openfasttrace-maven-plugin`, see [project-with-plugins](src/test/resources/project-with-plugins/) as an example.
+
+```xml
+<plugin>
+    <groupId>org.itsallcode</groupId>
+    <artifactId>openfasttrace-maven-plugin</artifactId>
+    <version>2.0.0</version>
+    <configuration>
+        <failBuild>true</failBuild>
+    </configuration>
+    <dependencies>
+        <dependency>
+            <groupId>org.itsallcode</groupId>
+            <artifactId>openfasttrace-asciidoc-plugin</artifactId>
+            <version>0.1.0</version>
+        </dependency>
+    </dependencies>
+</plugin>
+```
+
 ### Configuration
 
 You can configure the plugin using the `<configuration>` element.

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.itsallcode</groupId>
     <artifactId>openfasttrace-maven-plugin</artifactId>
-    <version>2.0.0</version>
+    <version>2.1.0</version>
     <packaging>maven-plugin</packaging>
 
     <name>OpenFastTrace Maven Plugin</name>
@@ -15,10 +15,10 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>17</java.version>
-        <oft.version>4.0.0</oft.version>
+        <oft.version>4.1.0</oft.version>
         <maven.core.version>3.8.7</maven.core.version>
         <skipSigningArtifacts>true</skipSigningArtifacts>
-        <junit.version>5.11.0-M2</junit.version>
+        <junit.version>5.11.0-RC1</junit.version>
         <jacoco.version>0.8.12</jacoco.version>
         <sonar.organization>itsallcode</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
@@ -130,7 +130,7 @@
             <!-- Fix CVE-2012-2098 and CVE-2023-37460 in dependency of maven-plugin-testing-harness -->
             <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-archiver</artifactId>
-            <version>4.9.2</version>
+            <version>4.10.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -155,13 +155,13 @@
         <dependency>
             <groupId>com.exasol</groupId>
             <artifactId>maven-plugin-integration-testing</artifactId>
-            <version>1.1.2</version>
+            <version>1.1.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>3.26.0</version>
+            <version>3.26.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -230,7 +230,7 @@
             <plugin>
                 <groupId>io.github.git-commit-id</groupId>
                 <artifactId>git-commit-id-maven-plugin</artifactId>
-                <version>9.0.0</version>
+                <version>9.0.1</version>
                 <executions>
                     <execution>
                         <id>get-the-git-infos</id>
@@ -291,7 +291,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-clean-plugin</artifactId>
-                <version>3.3.2</version>
+                <version>3.4.0</version>
                 <configuration>
                     <filesets>
                         <fileset>
@@ -345,7 +345,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <!-- Upgrade to a version that supports reproducible builds -->
-                <version>3.4.1</version>
+                <version>3.4.2</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -363,7 +363,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.7.0</version>
+                <version>3.8.0</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>
@@ -431,7 +431,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>3.6.1</version>
+                <version>3.7.1</version>
                 <executions>
                     <execution>
                         <id>copy-jacoco</id>
@@ -451,7 +451,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.2.5</version>
+                <version>3.3.1</version>
                 <configuration>
                     <excludes>
                         <exclude>**VerifierTest.java</exclude>
@@ -464,7 +464,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.2.5</version>
+                <version>3.3.1</version>
                 <configuration>
                     <includes>
                         <include>**VerifierTest.java</include>
@@ -486,7 +486,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>versions-maven-plugin</artifactId>
-                <version>2.16.2</version>
+                <version>2.17.1</version>
                 <configuration>
                     <excludes>
                         <!-- Pin Maven version to 3.x -->
@@ -516,6 +516,31 @@
                         <exclude>CVE-2023-2976</exclude>
                         <exclude>CVE-2020-8908</exclude>
                     </excludeVulnerabilityIds>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.basepom.maven</groupId>
+                <artifactId>duplicate-finder-maven-plugin</artifactId>
+                <version>2.0.1</version>
+                <executions>
+                    <execution>
+                        <id>default</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <printEqualFiles>true</printEqualFiles>
+                    <failBuildInCaseOfDifferentContentConflict>true</failBuildInCaseOfDifferentContentConflict>
+                    <failBuildInCaseOfEqualContentConflict>true</failBuildInCaseOfEqualContentConflict>
+                    <failBuildInCaseOfConflict>true</failBuildInCaseOfConflict>
+                    <checkCompileClasspath>true</checkCompileClasspath>
+                    <checkRuntimeClasspath>true</checkRuntimeClasspath>
+                    <checkTestClasspath>false</checkTestClasspath>
+                    <preferLocal>true</preferLocal>
+                    <useResultFile>false</useResultFile>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -80,11 +80,6 @@
         </dependency>
         <dependency>
             <groupId>org.itsallcode.openfasttrace</groupId>
-            <artifactId>openfasttrace-core</artifactId>
-            <version>${oft.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.itsallcode.openfasttrace</groupId>
             <artifactId>openfasttrace</artifactId>
             <version>${oft.version}</version>
             <scope>runtime</scope>
@@ -532,15 +527,20 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <printEqualFiles>true</printEqualFiles>
+                    <printEqualFiles>false</printEqualFiles>
                     <failBuildInCaseOfDifferentContentConflict>true</failBuildInCaseOfDifferentContentConflict>
-                    <failBuildInCaseOfEqualContentConflict>true</failBuildInCaseOfEqualContentConflict>
-                    <failBuildInCaseOfConflict>true</failBuildInCaseOfConflict>
+                    <!-- Workaround for https://github.com/itsallcode/openfasttrace/issues/428 -->
+                    <failBuildInCaseOfEqualContentConflict>false</failBuildInCaseOfEqualContentConflict>
+                    <failBuildInCaseOfConflict>false</failBuildInCaseOfConflict>
                     <checkCompileClasspath>true</checkCompileClasspath>
                     <checkRuntimeClasspath>true</checkRuntimeClasspath>
                     <checkTestClasspath>false</checkTestClasspath>
                     <preferLocal>true</preferLocal>
                     <useResultFile>false</useResultFile>
+                    <ignoredResourcePatterns>
+                         <!-- Suppress warning "Found duplicate and different resources in [org.eclipse.sisu:org.eclipse.sisu.inject:0.3.5, org.eclipse.sisu:org.eclipse.sisu.plexus:0.3.5]" -->
+                        <ignoredResourcePattern>about.html</ignoredResourcePattern>
+                    </ignoredResourcePatterns>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
             <groupId>org.itsallcode.openfasttrace</groupId>
             <artifactId>openfasttrace</artifactId>
             <version>${oft.version}</version>
-            <scope>runtime</scope>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.codehaus.plexus</groupId>

--- a/src/test/java/org/itsallcode/openfasttrace/maven/TraceMojoVerifierTest.java
+++ b/src/test/java/org/itsallcode/openfasttrace/maven/TraceMojoVerifierTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.nio.file.*;
@@ -22,7 +21,7 @@ import com.exasol.mavenpluginintegrationtesting.MavenIntegrationTestEnvironment;
 class TraceMojoVerifierTest
 {
     private static final Logger LOG = Logger.getLogger(TraceMojoVerifierTest.class.getName());
-    private static Path BASE_TEST_DIR = Paths.get("src/test/resources").toAbsolutePath();
+    private static final Path BASE_TEST_DIR = Paths.get("src/test/resources").toAbsolutePath();
     private static final String CURRENT_PLUGIN_VERSION = getCurrentProjectVersion();
     private static final String OFT_GOAL = "org.itsallcode:openfasttrace-maven-plugin:" + CURRENT_PLUGIN_VERSION
             + ":trace";
@@ -135,21 +134,12 @@ class TraceMojoVerifierTest
     @Test
     void testTracingWithPlugins() throws Exception
     {
-        installAsciiDocImporter();
         runTracingMojo(PROJECT_WITH_PLUGINS);
 
         assertThat(fileContent(PROJECT_WITH_PLUGINS.resolve("target/reports/tracing-report.txt")))
                 .isEqualTo("ok - 6 total\n");
     }
 
-    private static void installAsciiDocImporter()
-    {
-        final Path pluginPath = Path.of("../openfasttrace-asciidoc-plugin").toAbsolutePath();
-        final Path pluginJar = pluginPath.resolve("target/openfasttrace-asciidoc-plugin-0.1.0.jar");
-        assertTrue(Files.exists(pluginJar), "AsciiDoc plugin exists at " + pluginJar);
-        mvnITEnv.installPlugin(pluginJar.toFile(),
-                pluginPath.resolve("pom.xml").toFile());
-    }
 
     @Test
     void testTracingFindsDefects() throws Exception

--- a/src/test/java/org/itsallcode/openfasttrace/maven/TraceMojoVerifierTest.java
+++ b/src/test/java/org/itsallcode/openfasttrace/maven/TraceMojoVerifierTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.nio.file.*;
@@ -35,6 +36,7 @@ class TraceMojoVerifierTest
     private static final Path PROJECT_WITH_NESTED_SUB_MODULE = BASE_TEST_DIR.resolve("project-with-nested-sub-module");
     private static final Path EMPTY_PROJECT = BASE_TEST_DIR.resolve("empty-project");
     private static final Path SIMPLE_PROJECT = BASE_TEST_DIR.resolve("simple-project");
+    private static final Path PROJECT_WITH_PLUGINS = BASE_TEST_DIR.resolve("project-with-plugins");
     private static final Path TRACING_DEFECTS = BASE_TEST_DIR.resolve("project-with-tracing-defects");
     private static final Path TRACING_DEFECTS_FAIL_BUILD = BASE_TEST_DIR
             .resolve("project-with-tracing-defects-fail-build");
@@ -128,6 +130,25 @@ class TraceMojoVerifierTest
 
         assertThat(fileContent(SIMPLE_PROJECT.resolve("target/reports/tracing-report.txt")))
                 .isEqualTo("ok - 3 total\n");
+    }
+
+    @Test
+    void testTracingWithPlugins() throws Exception
+    {
+        installAsciiDocImporter();
+        runTracingMojo(PROJECT_WITH_PLUGINS);
+
+        assertThat(fileContent(PROJECT_WITH_PLUGINS.resolve("target/reports/tracing-report.txt")))
+                .isEqualTo("ok - 6 total\n");
+    }
+
+    private static void installAsciiDocImporter()
+    {
+        final Path pluginPath = Path.of("../openfasttrace-asciidoc-plugin").toAbsolutePath();
+        final Path pluginJar = pluginPath.resolve("target/openfasttrace-asciidoc-plugin-0.1.0.jar");
+        assertTrue(Files.exists(pluginJar), "AsciiDoc plugin exists at " + pluginJar);
+        mvnITEnv.installPlugin(pluginJar.toFile(),
+                pluginPath.resolve("pom.xml").toFile());
     }
 
     @Test

--- a/src/test/java/org/itsallcode/openfasttrace/maven/TraceMojoVerifierTest.java
+++ b/src/test/java/org/itsallcode/openfasttrace/maven/TraceMojoVerifierTest.java
@@ -140,7 +140,6 @@ class TraceMojoVerifierTest
                 .isEqualTo("ok - 6 total\n");
     }
 
-
     @Test
     void testTracingFindsDefects() throws Exception
     {

--- a/src/test/resources/project-with-plugins/doc/spec.adoc
+++ b/src/test/resources/project-with-plugins/doc/spec.adoc
@@ -1,0 +1,6 @@
+== AsciiDoc Spec
+
+[.specitem, oft-sid="dsn~asciidoc-exampleB~1", oft-needs="impl,test"]
+=== Example AsciiDoc Requirement
+
+Example AsciiDoc requirement

--- a/src/test/resources/project-with-plugins/doc/spec.md
+++ b/src/test/resources/project-with-plugins/doc/spec.md
@@ -1,0 +1,6 @@
+# MarkDown Tracing Example
+`dsn~md-exampleA~1`
+
+Example MarkDown requirement
+
+Needs: impl, test

--- a/src/test/resources/project-with-plugins/pom.xml
+++ b/src/test/resources/project-with-plugins/pom.xml
@@ -19,14 +19,6 @@
             <plugin>
                 <groupId>org.itsallcode</groupId>
                 <artifactId>openfasttrace-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>trace-requirements</id>
-                        <goals>
-                            <goal>trace</goal>
-                        </goals>
-                    </execution>
-                </executions>
                 <configuration>
                     <outputDirectory>${project.build.directory}/reports/</outputDirectory>
                     <reportOutputFormat>plain</reportOutputFormat>

--- a/src/test/resources/project-with-plugins/pom.xml
+++ b/src/test/resources/project-with-plugins/pom.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.itsallcode</groupId>
+    <artifactId>openfasttrace-maven-plugin-test</artifactId>
+    <version>0.0.0</version>
+    <packaging>jar</packaging>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.itsallcode</groupId>
+                <artifactId>openfasttrace-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>trace-requirements</id>
+                        <goals>
+                            <goal>trace</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <outputDirectory>${project.build.directory}/reports/</outputDirectory>
+                    <reportOutputFormat>plain</reportOutputFormat>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.itsallcode</groupId>
+                        <artifactId>openfasttrace-asciidoc-plugin</artifactId>
+                        <version>0.1.0</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/test/resources/project-with-plugins/pom.xml
+++ b/src/test/resources/project-with-plugins/pom.xml
@@ -27,7 +27,7 @@
                     <dependency>
                         <groupId>org.itsallcode</groupId>
                         <artifactId>openfasttrace-asciidoc-plugin</artifactId>
-                        <version>0.1.0</version>
+                        <version>0.2.0</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/src/test/resources/project-with-plugins/src/main/java/Source.java
+++ b/src/test/resources/project-with-plugins/src/main/java/Source.java
@@ -1,0 +1,6 @@
+// [impl->dsn~md-exampleA~1]
+// [impl->dsn~asciidoc-exampleB~1]
+class Source
+{
+    // Testing requirement tracing
+}

--- a/src/test/resources/project-with-plugins/src/test/java/Test.java
+++ b/src/test/resources/project-with-plugins/src/test/java/Test.java
@@ -1,0 +1,6 @@
+// [test->dsn~md-exampleA~1]
+// [test->dsn~asciidoc-exampleB~1]
+class Test
+{
+    // Testing requirement tracing
+}

--- a/src/test/resources/simple-project/pom.xml
+++ b/src/test/resources/simple-project/pom.xml
@@ -19,14 +19,6 @@
             <plugin>
                 <groupId>org.itsallcode</groupId>
                 <artifactId>openfasttrace-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>trace-requirements</id>
-                        <goals>
-                            <goal>trace</goal>
-                        </goals>
-                    </execution>
-                </executions>
                 <configuration>
                     <outputDirectory>${project.build.directory}/reports/</outputDirectory>
                     <reportOutputFormat>plain</reportOutputFormat>


### PR DESCRIPTION
This pull requests adds an integration test that verifies that `openfasttrace-maven-plugin` supports third party OFT-plugins and documents how to add plugins to the build.